### PR TITLE
feat: add a validatition fallback directive

### DIFF
--- a/projects/demo/.eslintrc.json
+++ b/projects/demo/.eslintrc.json
@@ -1,18 +1,11 @@
 {
   "extends": "../../.eslintrc.json",
-  "ignorePatterns": [
-    "!**/*"
-  ],
+  "ignorePatterns": ["!**/*"],
   "overrides": [
     {
-      "files": [
-        "*.ts"
-      ],
+      "files": ["*.ts"],
       "parserOptions": {
-        "project": [
-          "projects/demo/tsconfig.app.json",
-          "projects/demo/tsconfig.spec.json"
-        ],
+        "project": ["projects/demo/tsconfig.app.json", "projects/demo/tsconfig.spec.json"],
         "createDefaultProgram": true
       },
       "rules": {

--- a/projects/demo/src/app/home/home.component.html
+++ b/projects/demo/src/app/home/home.component.html
@@ -61,6 +61,10 @@
       <li>I18n possible</li>
       <li>HTML in messages possible</li>
       <li>Use of pipes in messages possible</li>
+      <li>
+        A fallback message can be specified to handle forgotten errors or to display multiple error types the same way using i18n (see API
+        documentation)
+      </li>
     </ul>
   </div>
 </div>

--- a/projects/ngx-valdemort/.eslintrc.json
+++ b/projects/ngx-valdemort/.eslintrc.json
@@ -1,18 +1,11 @@
 {
   "extends": "../../.eslintrc.json",
-  "ignorePatterns": [
-    "!**/*"
-  ],
+  "ignorePatterns": ["!**/*"],
   "overrides": [
     {
-      "files": [
-        "*.ts"
-      ],
+      "files": ["*.ts"],
       "parserOptions": {
-        "project": [
-          "projects/ngx-valdemort/tsconfig.lib.json",
-          "projects/ngx-valdemort/tsconfig.spec.json"
-        ],
+        "project": ["projects/ngx-valdemort/tsconfig.lib.json", "projects/ngx-valdemort/tsconfig.spec.json"],
         "createDefaultProgram": true
       },
       "rules": {

--- a/projects/ngx-valdemort/src/lib/default-validation-errors.directive.ts
+++ b/projects/ngx-valdemort/src/lib/default-validation-errors.directive.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @angular-eslint/directive-selector,@angular-eslint/no-host-metadata-property */
-import { AfterContentInit, ContentChildren, Directive, QueryList } from '@angular/core';
+import { AfterContentInit, ContentChild, ContentChildren, Directive, QueryList } from '@angular/core';
 import { DefaultValidationErrors } from './default-validation-errors.service';
 import { ValidationErrorDirective } from './validation-error.directive';
+import { ValidationFallbackDirective } from './validation-fallback.directive';
 
 /**
  * Directive allowing to register default templates for validation error messages. It's supposed to be used once,
@@ -27,6 +28,18 @@ import { ValidationErrorDirective } from './validation-error.directive';
  *   </val-default-errors>
  * ```
  *
+ * A fallback template can also be provided. This fallback template is used for all the errors that exist on the form control
+ * but are not handled by any of the specific error templates:
+ * ```
+ *   <val-default-errors>
+ *     <ng-template valError="required" let-label>{{ label }} is mandatory</ng-template>
+ *     <ng-template valError="max" let-error="error" let-label>{{ label }} must be at most {{ error.max | number }}</ng-template>
+ *     <ng-template valFallback let-label let-type="type" let-error="error">{{ label }} has an unhandled error of type {{ type }}: {{ error | json }}</ng-template>
+ *   </val-default-errors>
+ * ```
+ * Using the fallback can also be used to handle all the errors the same way, for example by using the error type as an i18n key
+ * to display the appropriate error message.
+ *
  * This directive stores the default template references in a service, that is then injected in the validation errors components
  * to be reused.
  */
@@ -41,12 +54,19 @@ export class DefaultValidationErrorsDirective implements AfterContentInit {
 
   /**
    * The list of validation error directives (i.e. <ng-template valError="...">)
-   * contained inside the component element.
+   * contained inside the directive element.
    */
   @ContentChildren(ValidationErrorDirective)
   errorDirectives!: QueryList<ValidationErrorDirective>;
 
+  /**
+   * The validation fallback directive (i.e. <ng-template valFallback>) contained inside the directive element.
+   */
+  @ContentChild(ValidationFallbackDirective)
+  fallbackDirective: ValidationFallbackDirective | undefined;
+
   ngAfterContentInit(): void {
     this.defaultValidationErrors.directives = this.errorDirectives.toArray();
+    this.defaultValidationErrors.fallback = this.fallbackDirective;
   }
 }

--- a/projects/ngx-valdemort/src/lib/default-validation-errors.service.ts
+++ b/projects/ngx-valdemort/src/lib/default-validation-errors.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ValidationErrorDirective } from './validation-error.directive';
+import { ValidationFallbackDirective } from './validation-fallback.directive';
 
 /**
  * Service used by the default validation errors directive to store the default error template references. This
@@ -10,4 +11,5 @@ import { ValidationErrorDirective } from './validation-error.directive';
 })
 export class DefaultValidationErrors {
   directives: Array<ValidationErrorDirective> = [];
+  fallback: ValidationFallbackDirective | undefined;
 }

--- a/projects/ngx-valdemort/src/lib/valdemort.module.ts
+++ b/projects/ngx-valdemort/src/lib/valdemort.module.ts
@@ -3,10 +3,11 @@ import { ValidationErrorsComponent } from './validation-errors.component';
 import { CommonModule } from '@angular/common';
 import { DefaultValidationErrorsDirective } from './default-validation-errors.directive';
 import { ValidationErrorDirective } from './validation-error.directive';
+import { ValidationFallbackDirective } from './validation-fallback.directive';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ValidationErrorsComponent, ValidationErrorDirective, DefaultValidationErrorsDirective],
-  exports: [ValidationErrorsComponent, ValidationErrorDirective, DefaultValidationErrorsDirective]
+  declarations: [ValidationErrorsComponent, ValidationErrorDirective, ValidationFallbackDirective, DefaultValidationErrorsDirective],
+  exports: [ValidationErrorsComponent, ValidationErrorDirective, ValidationFallbackDirective, DefaultValidationErrorsDirective]
 })
 export class ValdemortModule {}

--- a/projects/ngx-valdemort/src/lib/validation-errors.component.html
+++ b/projects/ngx-valdemort/src/lib/validation-errors.component.html
@@ -1,10 +1,21 @@
 <ng-container *ngIf="shouldDisplayErrors">
-  <div [class]="errorClasses" *ngFor="let errorDirective of errorDirectivesToDisplay">
-    <ng-container
-      *ngTemplateOutlet="errorDirective!.templateRef; context: {
-      $implicit: label,
-      error: actualControl.errors![errorDirective.type]
-    }"
-    ></ng-container>
-  </div>
+  <ng-container *ngIf="errorsToDisplay as e">
+    <div [class]="errorClasses" *ngFor="let errorDirective of e.errors">
+      <ng-container
+        *ngTemplateOutlet="errorDirective!.templateRef; context: {
+        $implicit: label,
+        error: actualControl!.errors![errorDirective.type]
+      }"
+      ></ng-container>
+    </div>
+    <div [class]="errorClasses" *ngFor="let error of e.fallbackErrors">
+      <ng-container
+        *ngTemplateOutlet="e.fallback!.templateRef; context: {
+        $implicit: label,
+        type: error.type,
+        error: error.value
+      }"
+      ></ng-container>
+    </div>
+  </ng-container>
 </ng-container>

--- a/projects/ngx-valdemort/src/lib/validation-fallback.directive.ts
+++ b/projects/ngx-valdemort/src/lib/validation-fallback.directive.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @angular-eslint/directive-selector,@angular-eslint/no-input-rename */
+import { Directive, TemplateRef } from '@angular/core';
+
+/**
+ * Directive allowing to define a fallback template for an error of a type that is not handled by any validation error directive.
+ * It's used inside the body of the validation errors component, or inside the body of the default validation errors directive.
+ * See the documentation of these two for example usages.
+ *
+ * This is useful to handle forgotten errors instead of displaying no error at all, or to handle all or several error types in the same way,
+ * for example by relying on the error key to choose an internationalized message.
+ */
+@Directive({ selector: 'ng-template[valFallback]' })
+export class ValidationFallbackDirective {
+  constructor(public templateRef: TemplateRef<unknown>) {}
+}

--- a/projects/ngx-valdemort/src/public_api.ts
+++ b/projects/ngx-valdemort/src/public_api.ts
@@ -5,6 +5,7 @@
 
 export * from './lib/default-validation-errors.directive';
 export * from './lib/validation-error.directive';
+export * from './lib/validation-fallback.directive';
 export * from './lib/validation-errors.component';
 export * from './lib/valdemort-config.service';
 export * from './lib/valdemort.module';


### PR DESCRIPTION
I chose to design it the following way
- name it valFallback instead of valDefaultError, to avoid confusion with the default-validation-errors directive
- expose the label, the error, and the type of the error to the fallback template
- if the display mode is ALL, then all the errors are displayed. So if two or more errors are not handled by specific error directives, the fallback template is displayed several time. I expect this to rarely happen. But it allows using the error type as an i18n key to display all the errors the same way. If the fallback is used to handle forgotten error types, then it will at least make it clear that several types have been forgotten.
- if the display mode is ONE, then the fallback template is only displayed once, if no error is handled by a specific error directive. Since there might be several errors handled by the fallback, the order is undefined, and we thus have no guarantee over which of the error will be displayed.

fix #264