### PR TITLE
chore: use max-warnings for ng lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test --no-progress --no-watch --code-coverage --project ngx-valdemort",
     "build:demo": "ng build --no-progress --prod --project demo",
     "test:demo": "ng test --no-progress --no-watch --project demo",
-    "lint": "ng lint",
+    "lint": "ng lint --max-warnings=0",
     "e2e": "ng e2e",
     "codecov": "codecov",
     "doc": "node scripts/prepare-doc.js && cd projects/ngx-valdemort && compodoc",


### PR DESCRIPTION
Fixes #272