### PR TITLE
feat: improve typing of the structural directives

### DIFF
--- a/projects/ngx-valdemort/src/lib/validation-error.directive.ts
+++ b/projects/ngx-valdemort/src/lib/validation-error.directive.ts
@@ -2,6 +2,21 @@
 import { Directive, Input, TemplateRef } from '@angular/core';
 
 /**
+ * The context of the ValidationErrorDirective
+ */
+interface ValidationErrorContext {
+  /**
+   * The label
+   */
+  $implicit: string | null;
+
+  /**
+   * The error
+   */
+  error: any;
+}
+
+/**
  * Directive allowing to define the template for an error of a given type (using the `valError` input), using an ng-template.
  * It's used inside the body of the validation errors component, or inside the body of the default validation errors directive.
  * See the documentation of these two for example usages.
@@ -13,5 +28,9 @@ export class ValidationErrorDirective {
    */
   @Input('valError') type = '';
 
-  constructor(public templateRef: TemplateRef<unknown>) {}
+  constructor(public templateRef: TemplateRef<ValidationErrorContext>) {}
+
+  static ngTemplateContextGuard(directive: ValidationErrorDirective, context: unknown): context is ValidationErrorContext {
+    return true;
+  }
 }

--- a/projects/ngx-valdemort/src/lib/validation-fallback.directive.ts
+++ b/projects/ngx-valdemort/src/lib/validation-fallback.directive.ts
@@ -2,6 +2,26 @@
 import { Directive, TemplateRef } from '@angular/core';
 
 /**
+ * The context of the ValidationFallbackDirective
+ */
+interface ValidationFallbackContext {
+  /**
+   * The label
+   */
+  $implicit: string | null;
+
+  /**
+   * The error
+   */
+  error: any;
+
+  /**
+   * The type of the error
+   */
+  type: string;
+}
+
+/**
  * Directive allowing to define a fallback template for an error of a type that is not handled by any validation error directive.
  * It's used inside the body of the validation errors component, or inside the body of the default validation errors directive.
  * See the documentation of these two for example usages.
@@ -11,5 +31,9 @@ import { Directive, TemplateRef } from '@angular/core';
  */
 @Directive({ selector: 'ng-template[valFallback]' })
 export class ValidationFallbackDirective {
-  constructor(public templateRef: TemplateRef<unknown>) {}
+  constructor(public templateRef: TemplateRef<ValidationFallbackContext>) {}
+
+  static ngTemplateContextGuard(directive: ValidationFallbackDirective, context: unknown): context is ValidationFallbackContext {
+    return true;
+  }
 }


### PR DESCRIPTION
When using `<ng-template valError="minlength" let-error="error" let-label>`, the compiler now knows the type of the error and of the label variables (same for valFallback), which allows for safer usage, and auto-completion.