### PR TITLE
feat: make the component OnPush

### DIFF
--- a/projects/ngx-valdemort/src/lib/validation-errors.component.html
+++ b/projects/ngx-valdemort/src/lib/validation-errors.component.html
@@ -1,16 +1,16 @@
-<ng-container *ngIf="shouldDisplayErrors">
-  <ng-container *ngIf="errorsToDisplay as e">
-    <div [class]="errorClasses" *ngFor="let errorDirective of e.errors">
+<ng-container *ngIf="vm() as vm">
+  <ng-container *ngIf="vm.shouldDisplayErrors">
+    <div [class]="errorClasses" *ngFor="let errorDirective of vm.errorsToDisplay.errors">
       <ng-container
         *ngTemplateOutlet="errorDirective!.templateRef; context: {
         $implicit: label,
-        error: actualControl!.errors![errorDirective.type]
+        error: vm.control.errors![errorDirective.type]
       }"
       ></ng-container>
     </div>
-    <div [class]="errorClasses" *ngFor="let error of e.fallbackErrors">
+    <div [class]="errorClasses" *ngFor="let error of vm.errorsToDisplay.fallbackErrors">
       <ng-container
-        *ngTemplateOutlet="e.fallback!.templateRef; context: {
+        *ngTemplateOutlet="vm.errorsToDisplay.fallback!.templateRef; context: {
         $implicit: label,
         type: error.type,
         error: error.value


### PR DESCRIPTION
I have no idea if this change actually makes a difference in terms of performance, but I think it should, because it doesn't recompute all the errors to display at each CD. 
And I fear that it's not actually completely safe to do it this way, so maybe we should just wait until forms use signals.