### PR TITLE
refactor: use signal inputs and queries, avoid RxJS dependency

### DIFF
--- a/projects/ngx-valdemort/src/lib/default-validation-errors.directive.ts
+++ b/projects/ngx-valdemort/src/lib/default-validation-errors.directive.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @angular-eslint/directive-selector,@angular-eslint/no-host-metadata-property */
-import { AfterContentInit, ContentChild, ContentChildren, Directive, QueryList } from '@angular/core';
+import { AfterContentInit, contentChild, contentChildren, Directive } from '@angular/core';
 import { DefaultValidationErrors } from './default-validation-errors.service';
 import { ValidationErrorDirective } from './validation-error.directive';
 import { ValidationFallbackDirective } from './validation-fallback.directive';
@@ -57,17 +57,15 @@ export class DefaultValidationErrorsDirective implements AfterContentInit {
    * The list of validation error directives (i.e. <ng-template valError="...">)
    * contained inside the directive element.
    */
-  @ContentChildren(ValidationErrorDirective)
-  errorDirectives!: QueryList<ValidationErrorDirective>;
+  errorDirectives = contentChildren(ValidationErrorDirective);
 
   /**
    * The validation fallback directive (i.e. <ng-template valFallback>) contained inside the directive element.
    */
-  @ContentChild(ValidationFallbackDirective)
-  fallbackDirective: ValidationFallbackDirective | undefined;
+  fallbackDirective = contentChild(ValidationFallbackDirective);
 
   ngAfterContentInit(): void {
-    this.defaultValidationErrors.directives = this.errorDirectives.toArray();
-    this.defaultValidationErrors.fallback = this.fallbackDirective;
+    this.defaultValidationErrors.directives.set(this.errorDirectives());
+    this.defaultValidationErrors.fallback.set(this.fallbackDirective());
   }
 }

--- a/projects/ngx-valdemort/src/lib/default-validation-errors.service.ts
+++ b/projects/ngx-valdemort/src/lib/default-validation-errors.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { ValidationErrorDirective } from './validation-error.directive';
 import { ValidationFallbackDirective } from './validation-fallback.directive';
 
@@ -10,6 +10,6 @@ import { ValidationFallbackDirective } from './validation-fallback.directive';
   providedIn: 'root'
 })
 export class DefaultValidationErrors {
-  directives: Array<ValidationErrorDirective> = [];
-  fallback: ValidationFallbackDirective | undefined;
+  readonly directives = signal<ReadonlyArray<ValidationErrorDirective>>([]);
+  readonly fallback = signal<ValidationFallbackDirective | undefined>(undefined);
 }

--- a/projects/ngx-valdemort/src/lib/validation-errors.component.html
+++ b/projects/ngx-valdemort/src/lib/validation-errors.component.html
@@ -6,7 +6,7 @@
           *ngTemplateOutlet="
             errorDirective!.templateRef;
             context: {
-              $implicit: label,
+              $implicit: label(),
               error: vm.control.errors![errorDirective.type]
             }
           "
@@ -19,7 +19,7 @@
           *ngTemplateOutlet="
             vm.errorsToDisplay.fallback!.templateRef;
             context: {
-              $implicit: label,
+              $implicit: label(),
               type: error.type,
               error: error.value
             }


### PR DESCRIPTION
Given that this relies on Angular 17.2 and on developer preview features, I suggest we only make the next release when Angular 18 comes out