### PR TITLE
fix: remove display none style from default validation errors directive

### DIFF
--- a/projects/ngx-valdemort/src/lib/default-validation-errors.directive.ts
+++ b/projects/ngx-valdemort/src/lib/default-validation-errors.directive.ts
@@ -43,10 +43,7 @@ import { ValidationFallbackDirective } from './validation-fallback.directive';
  * to be reused.
  */
 @Directive({
-  selector: 'val-default-errors',
-  host: {
-    style: 'display: none'
-  }
+  selector: 'val-default-errors'
 })
 export class DefaultValidationErrorsDirective implements AfterContentInit {
   private defaultValidationErrors = inject(DefaultValidationErrors);


### PR DESCRIPTION
If this removal affects your layout somehow, simply add the style by yourself on the val-default-errors element

fix #527