### PR TITLE
feat: change input name from `forField` to `formField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ which must be replaced by `<val-signal-errors>`:
 
 ```html
 <input type="email" [field]="form.email" />
-<val-signal-errors [forField]="form.email" label="The email" />
+<val-signal-errors [formField]="form.email" label="The email" />
 ```
 
 Learn more and see it in action on [our web page](https://ngx-valdemort.ninja-squad.com/)

--- a/projects/demo/public/snippets/signal-form.snippet.html
+++ b/projects/demo/public/snippets/signal-form.snippet.html
@@ -2,13 +2,13 @@
   <div class="mb-3">
     <label for="name" class="form-label">Name</label>
     <input [formField]="form.name" id="name" class="form-control" type="email" />
-    <val-signal-errors [forField]="form.name" label="The name" />
+    <val-signal-errors [formField]="form.name" label="The name" />
   </div>
 
   <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input [formField]="form.email" id="email" class="form-control" type="email" />
-    <val-signal-errors [forField]="form.email" label="The email" />
+    <val-signal-errors [formField]="form.email" label="The email" />
   </div>
 
   <button class="btn btn-primary me-2">Save</button>

--- a/projects/demo/src/app/signal-form/signal-form.component.html
+++ b/projects/demo/src/app/signal-form/signal-form.component.html
@@ -17,13 +17,13 @@
           <div class="mb-3">
             <label for="signal-form-name" class="form-label">Name</label>
             <input [formField]="form.name" id="signal-form-name" class="form-control" type="email" />
-            <val-signal-errors [forField]="form.name" label="The name" />
+            <val-signal-errors [formField]="form.name" label="The name" />
           </div>
 
           <div class="mb-3">
             <label for="signal-form-email" class="form-label">Email</label>
             <input [formField]="form.email" id="signal-form-email" class="form-control" type="email" />
-            <val-signal-errors [forField]="form.email" label="The email" />
+            <val-signal-errors [formField]="form.email" label="The email" />
           </div>
 
           <button class="btn btn-primary me-2">Save</button>
@@ -37,7 +37,7 @@
 <div [ngbNavOutlet]="nav"></div>
 
 <p>
-  Everything works the same way as in classic forms, except you must use <code>&lt;val-signal-errors [forField]="..." /&gt;</code> instead
+  Everything works the same way as in classic forms, except you must use <code>&lt;val-signal-errors [formField]="..." /&gt;</code> instead
   of <code>&lt;val-errors [control]="..." /&gt;</code>.
 </p>
 <p>Individual errors and default errors are defined with the same directives as for classic forms.</p>

--- a/projects/ngx-valdemort/src/lib/default-validation-errors.signals.directive.spec.ts
+++ b/projects/ngx-valdemort/src/lib/default-validation-errors.signals.directive.spec.ts
@@ -19,12 +19,12 @@ import { FormField, form, maxLength, minLength, pattern, required } from '@angul
     </val-default-errors>
 
     <input id="name" [formField]="form.name" />
-    <val-signal-errors id="name-errors" label="The name" [forField]="form.name">
+    <val-signal-errors id="name-errors" label="The name" [formField]="form.name">
       <ng-template valError="pattern">only letters</ng-template>
     </val-signal-errors>
 
     <input id="street" [formField]="form.street" />
-    <val-signal-errors id="street-errors" label="The street" [forField]="form.street">
+    <val-signal-errors id="street-errors" label="The street" [formField]="form.street">
       <ng-template valFallback>oops</ng-template>
     </val-signal-errors>
   `,

--- a/projects/ngx-valdemort/src/lib/validation-signal-errors.component.spec.ts
+++ b/projects/ngx-valdemort/src/lib/validation-signal-errors.component.spec.ts
@@ -12,33 +12,33 @@ import { ValidationFallbackDirective } from './validation-fallback.directive';
   template: `
     <form (submit)="save($event)" novalidate>
       <input [formField]="form.firstName" id="firstName" />
-      <val-signal-errors id="firstNameErrors" [forField]="form.firstName" label="The first name">
+      <val-signal-errors id="firstNameErrors" [formField]="form.firstName" label="The first name">
         <ng-template valError="required" let-label>{{ label }} is required</ng-template>
       </val-signal-errors>
 
       <input [formField]="form.lastName" id="lastName" />
-      <val-signal-errors id="lastNameErrors" [forField]="form.lastName">
+      <val-signal-errors id="lastNameErrors" [formField]="form.lastName">
         <ng-template valError="minLength" let-error="error">min length: {{ error.minLength }}</ng-template>
         <ng-template valError="pattern">only letters</ng-template>
       </val-signal-errors>
 
       <input [formField]="form.age" type="number" id="age" />
-      <val-signal-errors id="ageErrors" [forField]="form.age">
+      <val-signal-errors id="ageErrors" [formField]="form.age">
         <ng-template valError="required">age required</ng-template>
       </val-signal-errors>
 
       <div>
         <input [formField]="form.credentials.password" id="password" />
-        <val-signal-errors id="passwordErrors" [forField]="form.credentials.password">
+        <val-signal-errors id="passwordErrors" [formField]="form.credentials.password">
           <ng-template valError="required">password is required</ng-template>
         </val-signal-errors>
 
         <input [formField]="form.credentials.confirmation" />
-        <val-signal-errors id="confirmationErrors" [forField]="form.credentials.confirmation">
+        <val-signal-errors id="confirmationErrors" [formField]="form.credentials.confirmation">
           <ng-template valError="required">confirmation is required</ng-template>
         </val-signal-errors>
       </div>
-      <val-signal-errors id="credentialsErrors" [forField]="form.credentials">
+      <val-signal-errors id="credentialsErrors" [formField]="form.credentials">
         <ng-template valError="match">match with control error</ng-template>
       </val-signal-errors>
 
@@ -46,18 +46,18 @@ import { ValidationFallbackDirective } from './validation-fallback.directive';
         @for (hobbyField of form.hobbies; track hobbyField) {
           <div>
             <input [formField]="hobbyField" />
-            <val-signal-errors [forField]="hobbyField" id="hobbyErrors">
+            <val-signal-errors [formField]="hobbyField" id="hobbyErrors">
               <ng-template valError="required">each hobby required</ng-template>
             </val-signal-errors>
           </div>
         }
       </div>
-      <val-signal-errors [forField]="form.hobbies" id="hobbiesErrors">
+      <val-signal-errors [formField]="form.hobbies" id="hobbiesErrors">
         <ng-template valError="minLength">at least one hobby required</ng-template>
       </val-signal-errors>
 
       <input [formField]="form.email" id="email" />
-      <val-signal-errors id="emailErrors" [forField]="form.email" label="The email">
+      <val-signal-errors id="emailErrors" [formField]="form.email" label="The email">
         <ng-template valError="email">email must be a valid email address</ng-template>
         <ng-template valFallback let-label let-type="type">{{ label }} has an unhandled error of type {{ type }} </ng-template>
       </val-signal-errors>

--- a/projects/ngx-valdemort/src/lib/validation-signal-errors.component.ts
+++ b/projects/ngx-valdemort/src/lib/validation-signal-errors.component.ts
@@ -39,11 +39,11 @@ const NO_ERRORS: ViewModel = {
  * **Experimental**
  *
  * Component allowing to display validation error messages associated to a given field of a signal form.
- * The control is provided using the `forField` input of the component.
+ * The control is provided using the `formField` input of the component.
  *
  * Example usage:
  * ```
- *   <val-signal-errors [forField]="form.birthYear">
+ *   <val-signal-errors [formField]="form.birthYear">
  *     <ng-template valError="required">The birth year is mandatory</ng-template>
  *     <ng-template valError="max" let-error="error">The max value for the birth year is {{ error.max | number }}</ng-template>
  *   </val-errors>
@@ -54,7 +54,7 @@ const NO_ERRORS: ViewModel = {
  *
  * The label of the control can also be provided as input, and then used in the templates:
  * ```
- *   <val-signal-errors [forField]="form.birthYear" label="the birth year">
+ *   <val-signal-errors [formField]="form.birthYear" label="the birth year">
  *     <ng-template valError="required" let-label>{{ label }} is mandatory</ng-template>
  *     <ng-template valError="max" let-error="error" let-label>The max value for {{ label }} is {{ error.max | number }}</ng-template>
  *   </val-signal-errors>
@@ -71,20 +71,20 @@ const NO_ERRORS: ViewModel = {
  * need is
  *
  * ```
- * <val-signal-errors [forField]="form.birthYear" />
+ * <val-signal-errors [formField]="form.birthYear" />
  * ```
  *
  * or, if the default templates expect a label:
  *
  * ```
- * <val-signal-errors [forField]="form.birthYear" label="the birth year" />
+ * <val-signal-errors [formField]="form.birthYear" label="the birth year" />
  * ```
  *
  * If, however, you want to override one or several error messages by custom ones, you can do so by simply defining them inside the
  * component:
  *
  * ```
- * <val-signal-errors [forField]="form.birthYear" label="the birth year">
+ * <val-signal-errors [formField]="form.birthYear" label="the birth year">
  *   <ng-template valError="max">You're too young, sorry</ng-template>
  * </val-signal-errors>
  * ```
@@ -92,7 +92,7 @@ const NO_ERRORS: ViewModel = {
  * A fallback template can also be provided. This fallback template is used for all the errors that exist on the form control
  * but are not handled by any of the specific error templates:
  * ```
- * <val-signal-errors [forField]="form.birthYear" label="the birth year">
+ * <val-signal-errors [formField]="form.birthYear" label="the birth year">
  *   <ng-template valError="max">You're too young, sorry</ng-template>
  *   <ng-template valFallback let-label let-type="type" let-error="error">{{ label }} has an unhandled error of kind {{ type }}: {{ error | json }}</ng-template>
  * </val-signal-errors>
@@ -118,8 +118,7 @@ export class ValidationSignalErrorsComponent {
   /**
    * The FieldTree containing the validation errors.
    */
-  // eslint-disable-next-line @angular-eslint/no-input-rename
-  readonly field = input.required<FieldTree<unknown>>({ alias: 'forField' });
+  readonly formField = input.required<FieldTree<unknown>>();
 
   /**
    * The label of the field, exposed to templates so they can use it in the error message.
@@ -150,7 +149,7 @@ export class ValidationSignalErrorsComponent {
   private readonly defaultValidationErrors = inject(DefaultValidationErrors);
 
   private readonly hasDisplayableError = computed<boolean>(() => {
-    const field = this.field();
+    const field = this.formField();
     const errors = field().errors();
     return (
       errors.length > 0 &&
@@ -165,7 +164,7 @@ export class ValidationSignalErrorsComponent {
   });
 
   private readonly shouldDisplayErrors = computed<boolean>(() => {
-    const field = this.field();
+    const field = this.formField();
     const fieldState = field();
     if (!fieldState.invalid() || !this.hasDisplayableError()) {
       return false;
@@ -186,7 +185,7 @@ export class ValidationSignalErrorsComponent {
   });
 
   private findErrorsToDisplay(): ErrorsToDisplay {
-    const field = this.field();
+    const field = this.formField();
     const fieldErrors = field().errors();
     const mergedErrors: Array<ErrorWithDirective> = [];
     const fallbackErrors: Array<ValidationError.WithField> = [];


### PR DESCRIPTION
Now that signal forms use `formField` instead of `field`, `forField` looks like a typo. We decided to use the same input name, `formField` instead.

BREAKING CHANGE:
The input of the experimental `val-signal-errors` component is now named `formField` instead of the previous `forField`.